### PR TITLE
Fixes #5 - problem with unterminated let and const statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ for an example of using Tamarin as a library.
 
 To execute a Tamarin script, pass the path of a script to the tamarin binary:
 
-     $ tamarin ./example/hello.tm
+     $ tamarin ./examples/hello.tm
 
 Scripts can be made executable by adding a suitable shebang line:
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -230,14 +230,19 @@ func (p *Parser) parseLetStatement() *ast.LetStatement {
 	}
 	p.nextToken()
 	stmt.Value = p.parseExpression(LOWEST)
-	for !p.curTokenIs(token.SEMICOLON) && !p.curTokenIs(token.NEWLINE) {
-		if p.curTokenIs(token.EOF) {
-			p.errors = append(p.errors, "unterminated let statement")
-			return nil
-		}
-		p.nextToken()
+	if stmt.Value == nil {
+		p.errors = append(p.errors, "let statement is missing a value")
+		return nil
 	}
-	return stmt
+	switch p.peekToken.Type {
+	case token.NEWLINE, token.SEMICOLON, token.EOF:
+		p.nextToken()
+		return stmt
+	default:
+		err := fmt.Sprintf("unexpected token after let statement: %s", p.peekToken.Literal)
+		p.errors = append(p.errors, err)
+		return nil
+	}
 }
 
 // parseDeclarationStatement parses a "i := value" statement as a "let" statement.
@@ -249,14 +254,19 @@ func (p *Parser) parseDeclarationStatement() *ast.LetStatement {
 	stmt := &ast.LetStatement{Token: p.curToken, Name: name}
 	p.nextToken()
 	stmt.Value = p.parseExpression(LOWEST)
-	for !p.curTokenIs(token.SEMICOLON) && !p.curTokenIs(token.NEWLINE) {
-		if p.curTokenIs(token.EOF) {
-			p.errors = append(p.errors, "unterminated let statement")
-			return nil
-		}
-		p.nextToken()
+	if stmt.Value == nil {
+		p.errors = append(p.errors, ":= statement is missing a value")
+		return nil
 	}
-	return stmt
+	switch p.peekToken.Type {
+	case token.NEWLINE, token.SEMICOLON, token.EOF:
+		p.nextToken()
+		return stmt
+	default:
+		err := fmt.Sprintf("unexpected token after := statement: %s", p.peekToken.Literal)
+		p.errors = append(p.errors, err)
+		return nil
+	}
 }
 
 // parseConstStatement parses a constant declaration.
@@ -271,14 +281,19 @@ func (p *Parser) parseConstStatement() *ast.ConstStatement {
 	}
 	p.nextToken()
 	stmt.Value = p.parseExpression(LOWEST)
-	for !p.curTokenIs(token.SEMICOLON) && !p.curTokenIs(token.NEWLINE) {
-		if p.curTokenIs(token.EOF) {
-			p.errors = append(p.errors, "unterminated const statement")
-			return nil
-		}
-		p.nextToken()
+	if stmt.Value == nil {
+		p.errors = append(p.errors, "const statement is missing a value")
+		return nil
 	}
-	return stmt
+	switch p.peekToken.Type {
+	case token.NEWLINE, token.SEMICOLON, token.EOF:
+		p.nextToken()
+		return stmt
+	default:
+		err := fmt.Sprintf("unexpected token after const statement: %s", p.peekToken.Literal)
+		p.errors = append(p.errors, err)
+		return nil
+	}
 }
 
 // parseReturnStatement parses a function return statement.

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -487,8 +487,8 @@ func TestIncompleThings(t *testing.T) {
 	}{
 		{`if ( true ) { `, "unterminated block statement"},
 		{`if ( true ) { puts( "OK" ) ; } else { `, "unterminated block statement"},
-		{`let x = `, "let statement is missing a value"},
-		{`const x =`, "const statement is missing a value"},
+		{`let x = `, "assignment statement is missing a value"},
+		{`const x =`, "assignment statement is missing a value"},
 		{`func foo( a, b ="steve", `, "unterminated function parameters"},
 		{`func foo() {`, "unterminated block statement"},
 		{`switch (foo) { `, "unterminated switch statement"},

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -487,8 +487,8 @@ func TestIncompleThings(t *testing.T) {
 	}{
 		{`if ( true ) { `, "unterminated block statement"},
 		{`if ( true ) { puts( "OK" ) ; } else { `, "unterminated block statement"},
-		{`let x = `, "unterminated let statement"},
-		{`const x =`, "unterminated const statement"},
+		{`let x = `, "let statement is missing a value"},
+		{`const x =`, "const statement is missing a value"},
 		{`func foo( a, b ="steve", `, "unterminated function parameters"},
 		{`func foo() {`, "unterminated block statement"},
 		{`switch (foo) { `, "unterminated switch statement"},

--- a/tests/eval_test.go
+++ b/tests/eval_test.go
@@ -1,0 +1,107 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cloudcmds/tamarin/evaluator"
+	"github.com/cloudcmds/tamarin/exec"
+	"github.com/cloudcmds/tamarin/object"
+	"github.com/stretchr/testify/require"
+)
+
+type TestCase struct {
+	Name          string
+	Text          string
+	ExpectedValue string
+	ExpectedType  string
+}
+
+func readFile(name string) string {
+	data, err := os.ReadFile(name)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}
+
+func parseExpectedValue(filename, text string) (value string, typ string, err error) {
+	lines := strings.Split(text, "\n")
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "// ") {
+			continue
+		}
+		if strings.HasPrefix(line, "// expected value:") {
+			value = strings.SplitN(line, ":", 2)[1]
+		} else if strings.HasPrefix(line, "// expected type:") {
+			typ = strings.SplitN(line, ":", 2)[1]
+		}
+	}
+	if value != "" {
+		return strings.TrimSpace(value), strings.TrimSpace(typ), nil
+	}
+	return "", "", errors.New("test file did not define an expected result")
+}
+
+func getTestCase(name string) (TestCase, error) {
+	input := readFile(name)
+	expectedValue, expectedType, err := parseExpectedValue(name, input)
+	if err != nil {
+		return TestCase{}, err
+	}
+	return TestCase{
+		Name:          name,
+		Text:          input,
+		ExpectedValue: expectedValue,
+		ExpectedType:  expectedType,
+	}, nil
+}
+
+func execute(ctx context.Context, input string) (object.Object, error) {
+	result, err := exec.Execute(ctx, exec.Opts{
+		Input:    string(input),
+		Importer: &evaluator.SimpleImporter{},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func listTestFiles() []string {
+	files, err := os.ReadDir(".")
+	if err != nil {
+		panic(err)
+	}
+	var testFiles []string
+	for _, f := range files {
+		if strings.HasSuffix(f.Name(), ".tm") {
+			testFiles = append(testFiles, f.Name())
+		}
+	}
+	return testFiles
+}
+
+func TestFiles(t *testing.T) {
+	for _, name := range listTestFiles() {
+		if !strings.HasSuffix(name, ".tm") {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			tc, err := getTestCase(name)
+			require.Nil(t, err)
+
+			ctx := context.Background()
+			result, err := execute(ctx, tc.Text)
+			require.Nil(t, err)
+
+			expectedType := object.Type(tc.ExpectedType)
+
+			require.Equal(t, tc.ExpectedValue, result.Inspect())
+			require.Equal(t, expectedType, result.Type())
+		})
+	}
+}

--- a/tests/gentest.sh
+++ b/tests/gentest.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+TIMESTAMP=`date +"%Y-%m-%d-%H-%M"`
+TEST_FILE="test-${TIMESTAMP}.tm"
+
+cat <<EOF >> ${TEST_FILE}
+// UPDATE THIS FILE FOR YOUR TEST
+// github issue: xyz
+// expected value: 10
+// expected type: INTEGER
+
+let a = 10
+EOF
+
+echo "created test file: ${TEST_FILE}"

--- a/tests/test-2022-11-15-22-36.tm
+++ b/tests/test-2022-11-15-22-36.tm
@@ -1,0 +1,5 @@
+// github issue: https://github.com/cloudcmds/tamarin/issues/5
+// expected value: 10
+// expected type: INTEGER
+
+let a = 10

--- a/tests/test-2022-11-15-22-37.tm
+++ b/tests/test-2022-11-15-22-37.tm
@@ -1,0 +1,5 @@
+// github issue: https://github.com/cloudcmds/tamarin/issues/5
+// expected value: 10
+// expected type: INTEGER
+
+const a = 10

--- a/tests/test-2022-11-15-22-39.tm
+++ b/tests/test-2022-11-15-22-39.tm
@@ -1,0 +1,14 @@
+// github issue: n/a
+// expected value: 10
+// expected type: INTEGER
+
+i := 0
+
+for {
+    i++
+    if i == 10 {
+        break
+    }
+}
+
+i

--- a/tests/test-2022-11-16-08-00.tm
+++ b/tests/test-2022-11-16-08-00.tm
@@ -1,0 +1,11 @@
+// github issue: n/a
+// expected value: [1, 2, 3]
+// expected type: ARRAY
+
+a := [
+    "1",
+    "22",
+    "333",
+]
+
+b := a.map(func(x) { len(x) } )

--- a/tests/test-2022-11-16-08-06.tm
+++ b/tests/test-2022-11-16-08-06.tm
@@ -1,0 +1,5 @@
+// github issue: n/a
+// expected value: 2
+// expected type: FLOAT
+
+math.sqrt(4.0)

--- a/tests/test-2022-11-16-08-08.tm
+++ b/tests/test-2022-11-16-08-08.tm
@@ -1,0 +1,8 @@
+// github issue: n/a
+// expected value: null
+// expected type: NULL
+
+id := uuid.v4()
+assert(type(id) == "string")
+assert(strings.count(id, "-") == 4)
+assert(len(id) == 36)

--- a/tests/test-2022-11-16-08-11.tm
+++ b/tests/test-2022-11-16-08-11.tm
@@ -1,0 +1,6 @@
+// UPDATE THIS FILE FOR YOUR TEST
+// github issue: xyz
+// expected value: 10
+// expected type: INTEGER
+
+let a = 10

--- a/tests/test-2022-11-16-08-13.tm
+++ b/tests/test-2022-11-16-08-13.tm
@@ -1,0 +1,21 @@
+// github issue: n/a
+// expected value: "hello"
+// expected type: STRING
+
+let s = "\"hello\""
+let j = json.unmarshal(s)
+assert(type(j) == "result")
+assert(j.is_ok())
+assert(!j.is_err())
+
+let v = j.unwrap()
+assert(type(v) == "string")
+assert(v == "hello")
+
+s = json.marshal(v)
+assert(type(s) == "result")
+assert(j.is_ok())
+assert(!j.is_err())
+
+assert(s.unwrap() == "\"hello\"")
+s.unwrap()


### PR DESCRIPTION
Fixes let and const statements when there is no newline or semicolon present.

Also adds a new testing mechanism. An easy way to drop a new `.tm` file into the `tests` directory and that will be automatically picked up by the test suite. Each file defined the expected result value and type in comments.

```
cd tests
./gentest.sh
```

Then edit the test file.
