### PR TITLE
Error handling updates

### DIFF
--- a/examples/err.tm
+++ b/examples/err.tm
@@ -1,3 +1,1 @@
-const
-let
-for (
+for (// FIXME

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -112,10 +112,11 @@ func Execute(ctx context.Context, opts Opts) (result object.Object, err error) {
 	}
 
 	// Parse the program
-	program, err := parser.Parse(opts.Input)
+	program, err := parser.ParseWithOpts(ctx, parser.Opts{
+		Input: opts.Input,
+		File:  opts.File,
+	})
 	if err != nil {
-		pe := err.(parser.ParserError)
-		fmt.Printf("loc: %+v\n", pe.StartPosition())
 		return nil, err
 	}
 

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -46,6 +46,9 @@ type Opts struct {
 	// Input is the main source code to execute.
 	Input string
 
+	// File is the name of the file being executed (optional).
+	File string
+
 	// Importer may optionally be supplied as an interface
 	// used to import modules. If not provided, any attempt
 	// to import will fail, halting execution with an error.
@@ -111,7 +114,9 @@ func Execute(ctx context.Context, opts Opts) (result object.Object, err error) {
 	// Parse the program
 	program, err := parser.Parse(opts.Input)
 	if err != nil {
-		return nil, fmt.Errorf("parse error: %w", err)
+		pe := err.(parser.ParserError)
+		fmt.Printf("loc: %+v\n", pe.StartPosition())
+		return nil, err
 	}
 
 	// Evaluate the program

--- a/internal/parser/errors.go
+++ b/internal/parser/errors.go
@@ -1,0 +1,123 @@
+package parser
+
+import (
+	"fmt"
+
+	"github.com/cloudcmds/tamarin/internal/token"
+)
+
+// ErrorOpts is a struct that holds a variety of error data.
+// All fields are optional, although one of `Cause` or `Message`
+// are recommended. If `Cause` is set, `Message` will be ignored.
+type ErrorOpts struct {
+	ErrType       string
+	Message       string
+	Cause         error
+	File          string
+	StartPosition token.Position
+	EndPosition   token.Position
+	SourceCode    string
+}
+
+// NewBaseParserError returns a new BaseParserError populated with
+// the given error data.
+func NewParserError(opts ErrorOpts) *BaseParserError {
+	return &BaseParserError{
+		errType:       opts.ErrType,
+		message:       opts.Message,
+		cause:         opts.Cause,
+		file:          opts.File,
+		startPosition: opts.StartPosition,
+		endPosition:   opts.EndPosition,
+		sourceCode:    opts.SourceCode,
+	}
+}
+
+// ParserError is an interface that all parser errors implement.
+type ParserError interface {
+	Type() string
+	Message() string
+	Cause() error
+	File() string
+	StartPosition() token.Position
+	EndPosition() token.Position
+	SourceCode() string
+	Error() string
+}
+
+// BaseParserError is the simplest implementation of ParserError.
+type BaseParserError struct {
+	// Type of the error, e.g. "syntax error"
+	errType string
+	// The error message
+	message string
+	// The wrapped error
+	cause error
+	// File where the error occurred
+	file string
+	// Start position of the error in the input string
+	startPosition token.Position
+	// End position of the error in the input string
+	endPosition token.Position
+	// Relevant line of source code text
+	sourceCode string
+}
+
+func (e *BaseParserError) Error() string {
+	var msg string
+	if e.cause != nil {
+		msg = e.cause.Error()
+	} else if e.message != "" {
+		msg = e.message
+	}
+	if e.errType != "" {
+		msg = fmt.Sprintf("%s: %s", e.errType, msg)
+	}
+	return msg
+}
+
+func (e *BaseParserError) Cause() error {
+	return e.cause
+}
+
+func (e *BaseParserError) Message() string {
+	return e.message
+}
+
+func (e *BaseParserError) Line() int {
+	return e.startPosition.Line
+}
+
+func (e *BaseParserError) StartPosition() token.Position {
+	return e.startPosition
+}
+
+func (e *BaseParserError) EndPosition() token.Position {
+	return e.endPosition
+}
+
+func (e *BaseParserError) File() string {
+	return e.file
+}
+
+func (e *BaseParserError) SourceCode() string {
+	return e.sourceCode
+}
+
+func (e *BaseParserError) Unwrap() error {
+	return e.cause
+}
+
+func (e *BaseParserError) Type() string {
+	return e.errType
+}
+
+// NewSyntaxError returns a new SyntaxError populated with the given error data
+func NewSyntaxError(opts ErrorOpts) *SyntaxError {
+	opts.ErrType = "syntax error"
+	return &SyntaxError{BaseParserError: NewParserError(opts)}
+}
+
+type SyntaxError struct {
+	*BaseParserError
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -432,6 +432,9 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 		return nil
 	}
 	leftExp := prefix()
+	if p.err != nil {
+		return nil
+	}
 	for !p.peekTokenIs(token.SEMICOLON) && precedence < p.peekPrecedence() {
 		infix := p.infixParseFns[p.peekToken.Type]
 		if infix == nil {
@@ -439,6 +442,9 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 		}
 		p.nextToken()
 		leftExp = infix(leftExp)
+		if p.err != nil {
+			break
+		}
 	}
 	p.eatNewlines()
 	return leftExp

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -6,7 +6,6 @@
 package parser
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -14,7 +13,6 @@ import (
 	"github.com/cloudcmds/tamarin/internal/ast"
 	"github.com/cloudcmds/tamarin/internal/lexer"
 	"github.com/cloudcmds/tamarin/internal/token"
-	"github.com/hashicorp/go-multierror"
 )
 
 type (
@@ -29,23 +27,40 @@ func Parse(input string) (*ast.Program, error) {
 	return New(lexer.New(input)).Parse()
 }
 
+// ParseWithOpts is a shortcut that can be used to parse the given Tamarin source code.
+// The lexer and parser are created internally and not exposed.
+func ParseWithOpts(opts Opts) (*ast.Program, error) {
+	lexerOpts := lexer.Opts{
+		Input: opts.Input,
+		File:  opts.File,
+	}
+	return New(lexer.NewWithOptions(lexerOpts)).Parse()
+}
+
+// Opts contains options for the parser.
+type Opts struct {
+	// Input is the string being parsed.
+	Input string
+	// File is the name of the file being parsed (optional).
+	File string
+}
+
 // Parser object
 type Parser struct {
 	// l is our lexer
 	l *lexer.Lexer
 
-	// prevToken holds the previous token from our lexer.
-	// (used for "++" + "--")
+	// prevToken holds the previous token, which we already processed.
 	prevToken token.Token
 
-	// curToken holds the current token from our lexer.
+	// curToken holds the current token from the lexer.
 	curToken token.Token
 
-	// peekToken holds the next token which will come from the lexer.
+	// peekToken holds the next token from the lexer.
 	peekToken token.Token
 
-	// errors holds parsing-errors.
-	errors []string
+	// the parsing error, if any
+	err ParserError
 
 	// prefixParseFns holds a map of parsing methods for
 	// prefix-based syntax.
@@ -71,24 +86,23 @@ func New(l *lexer.Lexer) *Parser {
 	// Create the parser and prime the token pump
 	p := &Parser{
 		l:               l,
-		errors:          []string{},
 		prefixParseFns:  map[token.Type]prefixParseFn{},
 		infixParseFns:   map[token.Type]infixParseFn{},
 		postfixParseFns: map[token.Type]postfixParseFn{},
 	}
-	p.nextToken() // loads peekToken with token0
-	p.nextToken() // loads curToken with token0 and peekToken with token1
+	p.nextToken() // makes curToken=<empty>, peekToken=token[0]
+	p.nextToken() // makes curToken=token[0], peekToken=token[1]
 
 	// Register prefix-functions
 	p.registerPrefix(token.BANG, p.parsePrefixExpression)
 	p.registerPrefix(token.FUNC, p.parseFunctionDefinition)
-	p.registerPrefix(token.EOF, p.parsingBroken)
+	p.registerPrefix(token.EOF, p.illegalToken)
 	p.registerPrefix(token.FALSE, p.parseBoolean)
 	p.registerPrefix(token.FLOAT, p.parseFloatLiteral)
 	p.registerPrefix(token.FOR, p.parseForLoopExpression)
 	p.registerPrefix(token.IDENT, p.parseIdentifier)
 	p.registerPrefix(token.IF, p.parseIfExpression)
-	p.registerPrefix(token.ILLEGAL, p.parsingBroken)
+	p.registerPrefix(token.ILLEGAL, p.illegalToken)
 	p.registerPrefix(token.INT, p.parseIntegerLiteral)
 	p.registerPrefix(token.LBRACE, p.parseHashLiteral)
 	p.registerPrefix(token.LBRACKET, p.parseArrayLiteral)
@@ -141,28 +155,58 @@ func New(l *lexer.Lexer) *Parser {
 }
 
 // nextToken moves to the next token from the lexer, updating all of
-// prevToken, curToken, and peekToken.
+// prevToken, curToken, and peekToken. Any lexer error is captured but
+// ignored.
 func (p *Parser) nextToken() {
+	p.nextTokenWithError()
+}
+
+// nextToken moves to the next token from the lexer, updating all of
+// prevToken, curToken, and peekToken.
+func (p *Parser) nextTokenWithError() error {
+	// If we have an error, we can't move forward
+	if p.err != nil {
+		return p.err
+	}
+	var err error
 	p.prevToken = p.curToken
 	p.curToken = p.peekToken
-	p.peekToken = p.l.NextToken()
+	p.peekToken, err = p.l.NextToken()
+	if err == nil {
+		return nil // success
+	}
+	// The lexer encountered an error. We consider all lexer errors
+	// "syntax errors" and parsing will now be considered broken.
+	p.err = NewSyntaxError(ErrorOpts{
+		Cause:         err,
+		File:          p.l.File(),
+		StartPosition: p.peekToken.StartPosition,
+		EndPosition:   p.peekToken.EndPosition,
+		SourceCode:    p.l.GetTokenLineText(p.peekToken),
+	})
+	return p.err
 }
 
 // Parse the program that is provided via the lexer.
 func (p *Parser) Parse() (*ast.Program, error) {
+	// It's possible for an error to already exist because we read tokens from
+	// the lexer in the constructor. Parsing is already broken if so.
+	if p.err != nil {
+		return nil, p.err
+	}
+	// Parse the entire input program as a series of statements.
+	// Parsing stops on the first occurence of an error.
 	program := &ast.Program{Statements: []ast.Statement{}}
 	for p.curToken.Type != token.EOF {
 		stmt := p.parseStatement()
 		if stmt != nil {
 			program.Statements = append(program.Statements, stmt)
 		}
-		p.nextToken()
+		if err := p.nextTokenWithError(); err != nil {
+			return nil, err
+		}
 	}
-	var combinedErrors error
-	for _, err := range p.Errors() {
-		combinedErrors = multierror.Append(combinedErrors, errors.New(err))
-	}
-	return program, combinedErrors
+	return program, p.err
 }
 
 // registerPrefix registers a function for handling a prefix-based statement.
@@ -180,22 +224,49 @@ func (p *Parser) registerPostfix(tokenType token.Type, fn postfixParseFn) {
 	p.postfixParseFns[tokenType] = fn
 }
 
-func (p *Parser) noPrefixParseFnError(t token.Type) {
-	msg := fmt.Sprintf("no prefix parse function for %s found around line %d",
-		t, p.curToken.Line+1)
-	p.errors = append(p.errors, msg)
-}
-
-// Errors returns all error messages accumulated during program parsing.
-func (p *Parser) Errors() []string {
-	return p.errors
+func (p *Parser) noPrefixParseFnError(t token.Token) {
+	if p.err != nil {
+		return
+	}
+	p.err = NewParserError(ErrorOpts{
+		ErrType:       "parse error",
+		Message:       fmt.Sprintf("unexpected token %s", t.Literal),
+		File:          p.l.File(),
+		StartPosition: t.StartPosition,
+		EndPosition:   t.EndPosition,
+		SourceCode:    p.l.GetTokenLineText(t),
+	})
 }
 
 // peekError raises an error if the next token is not the expected type.
-func (p *Parser) peekError(t token.Type) {
-	msg := fmt.Sprintf("expected next token to be %s, got %s instead around line %d:%d",
-		t, p.peekToken.Type, p.curToken.Line+1, p.curToken.EndPosition+2)
-	p.errors = append(p.errors, msg)
+func (p *Parser) peekError(context string, expected token.Type, got token.Token) {
+	if p.err != nil {
+		return
+	}
+	gotInfo := got.Literal
+	if gotInfo == "" {
+		gotInfo = string(got.Type)
+	}
+	expInfo := string(expected)
+	if expInfo == "IDENT" {
+		expInfo = "an identifier"
+	}
+	p.err = NewParserError(ErrorOpts{
+		ErrType: "parse error",
+		Message: fmt.Sprintf("unexpected %s while parsing %s (expected %s)",
+			gotInfo, context, expInfo),
+		File:          p.l.File(),
+		StartPosition: got.StartPosition,
+		EndPosition:   got.EndPosition,
+		SourceCode:    p.l.GetTokenLineText(got),
+	})
+}
+
+func (p *Parser) setError(err ParserError) {
+	if p.err != nil {
+		return
+	}
+	p.err = err
 }
 
 // parseStatement parses a single statement.
@@ -222,11 +293,11 @@ func (p *Parser) parseStatement() ast.Statement {
 // parseLetStatement parses a let statement.
 func (p *Parser) parseLetStatement() *ast.LetStatement {
 	stmt := &ast.LetStatement{Token: p.curToken}
-	if !p.expectPeek(token.IDENT) {
+	if !p.expectPeek("let statement", token.IDENT) {
 		return nil
 	}
 	stmt.Name = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
-	if !p.expectPeek(token.ASSIGN) {
+	if !p.expectPeek("let statement", token.ASSIGN) {
 		return nil
 	}
 	p.nextToken()
@@ -240,7 +311,7 @@ func (p *Parser) parseLetStatement() *ast.LetStatement {
 // parseDeclarationStatement parses a "i := value" statement as a "let" statement.
 func (p *Parser) parseDeclarationStatement() *ast.LetStatement {
 	name := &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
-	if !p.expectPeek(token.DECLARE) {
+	if !p.expectPeek("declaration statement", token.DECLARE) {
 		return nil
 	}
 	stmt := &ast.LetStatement{Token: p.curToken, Name: name}
@@ -255,11 +326,11 @@ func (p *Parser) parseDeclarationStatement() *ast.LetStatement {
 // parseConstStatement parses a constant declaration.
 func (p *Parser) parseConstStatement() *ast.ConstStatement {
 	stmt := &ast.ConstStatement{Token: p.curToken}
-	if !p.expectPeek(token.IDENT) {
+	if !p.expectPeek("const statement", token.IDENT) {
 		return nil
 	}
 	stmt.Name = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
-	if !p.expectPeek(token.ASSIGN) {
+	if !p.expectPeek("const statement", token.ASSIGN) {
 		return nil
 	}
 	p.nextToken()
@@ -276,7 +347,14 @@ func (p *Parser) parseAssignmentValue() ast.Expression {
 	// Parse the value being assigned (the right hand side)
 	result := p.parseExpression(LOWEST)
 	if result == nil {
-		p.errors = append(p.errors, "assignment statement is missing a value")
+		p.setError(NewParserError(ErrorOpts{
+			ErrType:       "parse error",
+			Message:       "assignment is missing a value",
+			File:          p.l.File(),
+			StartPosition: p.prevToken.EndPosition,
+			EndPosition:   p.prevToken.EndPosition,
+			SourceCode:    p.l.GetTokenLineText(p.prevToken),
+		}))
 		return nil
 	}
 	switch p.peekToken.Type {
@@ -285,8 +363,14 @@ func (p *Parser) parseAssignmentValue() ast.Expression {
 		p.nextToken()
 		return result
 	default:
-		err := fmt.Sprintf("assignment statement is followed by an unexpected token: %s", p.peekToken.Literal)
-		p.errors = append(p.errors, err)
+		p.setError(NewParserError(ErrorOpts{
+			ErrType:       "parse error",
+			Message:       fmt.Sprintf("unexpected token %s following assignment value", p.peekToken.Literal),
+			File:          p.l.File(),
+			StartPosition: p.peekToken.StartPosition,
+			EndPosition:   p.peekToken.EndPosition,
+			SourceCode:    p.l.GetTokenLineText(p.peekToken),
+		}))
 		return nil
 	}
 }
@@ -302,7 +386,14 @@ func (p *Parser) parseReturnStatement() *ast.ReturnStatement {
 			p.nextToken()
 			return stmt
 		default:
-			p.errors = append(p.errors, fmt.Sprintf("unexpected token in return statement: %s", p.peekToken.Literal))
+			p.setError(NewParserError(ErrorOpts{
+				ErrType:       "parse error",
+				Message:       fmt.Sprintf("unexpected token %s following return value", p.peekToken.Literal),
+				File:          p.l.File(),
+				StartPosition: p.peekToken.StartPosition,
+				EndPosition:   p.peekToken.EndPosition,
+				SourceCode:    p.l.GetTokenLineText(p.peekToken),
+			}))
 			return nil
 		}
 	}
@@ -328,13 +419,16 @@ func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
 }
 
 func (p *Parser) parseExpression(precedence int) ast.Expression {
+	if p.curToken.Type == token.EOF {
+		return nil
+	}
 	postfix := p.postfixParseFns[p.curToken.Type]
 	if postfix != nil {
 		return (postfix())
 	}
 	prefix := p.prefixParseFns[p.curToken.Type]
 	if prefix == nil {
-		p.noPrefixParseFnError(p.curToken.Type)
+		p.noPrefixParseFnError(p.curToken)
 		return nil
 	}
 	leftExp := prefix()
@@ -350,9 +444,27 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 	return leftExp
 }
 
-// parsingBroken is hit if we see an EOF in our input-stream
-// this means we're screwed
-func (p *Parser) parsingBroken() ast.Expression {
+func (p *Parser) illegalToken() ast.Expression {
+	p.setError(NewParserError(ErrorOpts{
+		ErrType:       "parse error",
+		Message:       fmt.Sprintf("illegal token %s", p.curToken.Literal),
+		File:          p.l.File(),
+		StartPosition: p.curToken.StartPosition,
+		EndPosition:   p.curToken.EndPosition,
+		SourceCode:    p.l.GetTokenLineText(p.curToken),
+	}))
+	return nil
+}
+
+func (p *Parser) setTokenError(t token.Token, msg string, args ...interface{}) ast.Expression {
+	p.setError(NewParserError(ErrorOpts{
+		ErrType:       "parse error",
+		Message:       fmt.Sprintf(msg, args...),
+		File:          p.l.File(),
+		StartPosition: t.StartPosition,
+		EndPosition:   t.EndPosition,
+		SourceCode:    p.l.GetTokenLineText(t),
+	}))
 	return nil
 }
 
@@ -377,9 +489,14 @@ func (p *Parser) parseIntegerLiteral() ast.Expression {
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("could not parse %q as integer around line %d",
-			p.curToken.Literal, p.curToken.Line+1)
-		p.errors = append(p.errors, msg)
+		p.setError(NewParserError(ErrorOpts{
+			ErrType:       "parse error",
+			Message:       fmt.Sprintf("invalid integer: %s", p.curToken.Literal),
+			File:          p.l.File(),
+			StartPosition: p.curToken.StartPosition,
+			EndPosition:   p.curToken.EndPosition,
+			SourceCode:    p.l.GetTokenLineText(p.curToken),
+		}))
 		return nil
 	}
 	lit.Value = value
@@ -388,16 +505,21 @@ func (p *Parser) parseIntegerLiteral() ast.Expression {
 
 // parseFloatLiteral parses a float-literal
 func (p *Parser) parseFloatLiteral() ast.Expression {
-	flo := &ast.FloatLiteral{Token: p.curToken}
+	f := &ast.FloatLiteral{Token: p.curToken}
 	value, err := strconv.ParseFloat(p.curToken.Literal, 64)
 	if err != nil {
-		msg := fmt.Sprintf("could not parse %q as float around line %d",
-			p.curToken.Literal, p.curToken.Line+1)
-		p.errors = append(p.errors, msg)
+		p.setError(NewParserError(ErrorOpts{
+			ErrType:       "parse error",
+			Message:       fmt.Sprintf("invalid float: %s", p.curToken.Literal),
+			File:          p.l.File(),
+			StartPosition: p.curToken.StartPosition,
+			EndPosition:   p.curToken.EndPosition,
+			SourceCode:    p.l.GetTokenLineText(p.curToken),
+		}))
 		return nil
 	}
-	flo.Value = value
-	return flo
+	f.Value = value
+	return f
 }
 
 // parseSwitchStatement handles a switch statement
@@ -408,7 +530,7 @@ func (p *Parser) parseSwitchStatement() ast.Expression {
 	if expression.Value == nil {
 		return nil
 	}
-	if !p.expectPeek(token.LBRACE) {
+	if !p.expectPeek("switch statement", token.LBRACE) {
 		return nil
 	}
 	p.nextToken()
@@ -417,12 +539,11 @@ func (p *Parser) parseSwitchStatement() ast.Expression {
 	// Process the block which we think will contain various case-statements
 	for !p.curTokenIs(token.RBRACE) {
 		if p.curTokenIs(token.EOF) {
-			p.errors = append(p.errors, "unterminated switch statement")
+			p.setTokenError(p.prevToken, "unterminated switch statement")
 			return nil
 		}
 		if p.curToken.Literal != "case" && p.curToken.Literal != "default" {
-			p.errors = append(p.errors, fmt.Sprintf("unexpected token %s; expected case or default",
-				p.curToken.Literal))
+			p.setTokenError(p.curToken, "expected 'case' or 'default' (got %s)", p.curToken.Literal)
 			return nil
 		}
 		tmp := &ast.CaseExpression{Token: p.curToken}
@@ -442,11 +563,10 @@ func (p *Parser) parseSwitchStatement() ast.Expression {
 				tmp.Expr = append(tmp.Expr, p.parseExpression(LOWEST))
 			}
 		} else {
-			// error - unexpected token
-			p.errors = append(p.errors, fmt.Sprintf("expected case|default, got %s", p.curToken.Type))
+			p.setTokenError(p.curToken, "expected 'case' or 'default' (got %s)", p.curToken.Literal)
 			return nil
 		}
-		if !p.expectPeek(token.COLON) {
+		if !p.expectPeek("switch statement", token.COLON) {
 			return nil
 		}
 		p.nextToken()
@@ -469,21 +589,22 @@ func (p *Parser) parseSwitchStatement() ast.Expression {
 	}
 	// More than one default is a bug
 	count := 0
+	var lastDefault token.Token
 	for _, c := range expression.Choices {
 		if c.Default {
 			count++
 		}
+		lastDefault = c.Token
 	}
 	if count > 1 {
-		msg := "A switch-statement should only have one default block"
-		p.errors = append(p.errors, msg)
+		p.setTokenError(lastDefault, "switch statement has multiple default blocks")
 		return nil
 	}
 	return expression
 }
 
 func (p *Parser) parseImportStatement() ast.Expression {
-	if !p.expectPeek(token.IDENT) {
+	if !p.expectPeek("an import statement", token.IDENT) {
 		return nil
 	}
 	return &ast.ImportStatement{
@@ -544,8 +665,7 @@ func (p *Parser) parseInfixExpression(left ast.Expression) ast.Expression {
 // parseTernaryExpression parses a ternary expression
 func (p *Parser) parseTernaryExpression(condition ast.Expression) ast.Expression {
 	if p.tern {
-		msg := fmt.Sprintf("nested ternary expressions are illegal, around line %d", p.curToken.Line+1)
-		p.errors = append(p.errors, msg)
+		p.setTokenError(p.curToken, "nested ternary expression detected")
 		return nil
 	}
 	p.tern = true
@@ -559,7 +679,7 @@ func (p *Parser) parseTernaryExpression(condition ast.Expression) ast.Expression
 	precedence := p.curPrecedence()
 	expression.IfTrue = p.parseExpression(precedence)
 
-	if !p.expectPeek(token.COLON) { //skip the ":"
+	if !p.expectPeek("ternary expression", token.COLON) { //skip the ":"
 		return nil
 	}
 
@@ -574,7 +694,7 @@ func (p *Parser) parseTernaryExpression(condition ast.Expression) ast.Expression
 func (p *Parser) parseGroupedExpression() ast.Expression {
 	p.nextToken()
 	exp := p.parseExpression(LOWEST)
-	if !p.expectPeek(token.RPAREN) {
+	if !p.expectPeek("grouped expression", token.RPAREN) {
 		return nil
 	}
 	return exp
@@ -589,15 +709,12 @@ func (p *Parser) parseIfExpression() ast.Expression {
 		return nil
 	}
 	// Now "{"
-	if !p.expectPeek(token.LBRACE) {
-		msg := fmt.Sprintf("expected '{' but got %s", p.curToken.Literal)
-		p.errors = append(p.errors, msg)
+	if !p.expectPeek("an if expression", token.LBRACE) {
 		return nil
 	}
 	// The consequence
 	expression.Consequence = p.parseBlockStatement()
 	if expression.Consequence == nil {
-		p.errors = append(p.errors, "unexpected nil expression")
 		return nil
 	}
 	// Optional else block
@@ -616,14 +733,11 @@ func (p *Parser) parseIfExpression() ast.Expression {
 			return expression
 		}
 		// else { block }
-		if !p.expectPeek(token.LBRACE) {
-			msg := fmt.Sprintf("expected '{' but got %s", p.curToken.Literal)
-			p.errors = append(p.errors, msg)
+		if !p.expectPeek("an if expression", token.LBRACE) {
 			return nil
 		}
 		expression.Alternative = p.parseBlockStatement()
 		if expression.Alternative == nil {
-			p.errors = append(p.errors, "unexpected nil expression")
 			return nil
 		}
 	}
@@ -648,24 +762,24 @@ func (p *Parser) parseForLoopExpression() ast.Expression {
 		expression.Consequence = p.parseBlockStatement()
 		return expression
 	default:
-		p.errors = append(p.errors, fmt.Sprintf("unexpected token in for loop: %s", p.peekToken.Literal))
+		p.setTokenError(p.peekToken, "unexpected token in for loop: %s", p.peekToken.Literal)
 		p.nextToken()
 		return nil
 	}
 	expression.InitStatement = initExpression
 
 	if !p.curTokenIs(token.SEMICOLON) {
-		p.errors = append(p.errors, "expected a semicolon")
+		p.setTokenError(p.curToken, "expected a semicolon (got %s)", p.curToken.Literal)
 		return nil
 	}
 	p.nextToken()
 
 	expression.Condition = p.parseExpression(LOWEST)
 
-	if !p.expectPeek(token.SEMICOLON) {
+	if !p.expectPeek("for loop", token.SEMICOLON) {
 		return nil
 	}
-	if !p.expectPeek(token.IDENT) {
+	if !p.expectPeek("for loop", token.IDENT) {
 		return nil
 	}
 	if p.peekTokenIs(token.PLUS_PLUS) || p.peekTokenIs(token.MINUS_MINUS) {
@@ -675,24 +789,23 @@ func (p *Parser) parseForLoopExpression() ast.Expression {
 		expression.PostStatement = p.parseExpression(LOWEST)
 	}
 	if expression.PostStatement == nil {
-		p.errors = append(p.errors, "unable to parse for loop post statement")
 		return nil
 	}
-	if !p.expectPeek(token.LBRACE) {
+	if !p.expectPeek("for loop", token.LBRACE) {
 		return nil
 	}
 	expression.Consequence = p.parseBlockStatement()
 	return expression
 }
 
-// parseBlockStatement parsea a block.
+// parseBlockStatement parses a block.
 func (p *Parser) parseBlockStatement() *ast.BlockStatement {
 	block := &ast.BlockStatement{Token: p.curToken}
 	block.Statements = []ast.Statement{}
 	p.nextToken()
 	for !p.curTokenIs(token.RBRACE) {
 		if p.curTokenIs(token.EOF) {
-			p.errors = append(p.errors, "unterminated block statement")
+			p.setTokenError(block.Token, "unterminated block statement")
 			return nil
 		}
 		stmt := p.parseStatement()
@@ -707,11 +820,11 @@ func (p *Parser) parseBlockStatement() *ast.BlockStatement {
 // parseFunctionLiteral parses a function-literal.
 func (p *Parser) parseFunctionLiteral() ast.Expression {
 	lit := &ast.FunctionLiteral{Token: p.curToken}
-	if !p.expectPeek(token.LPAREN) {
+	if !p.expectPeek("function", token.LPAREN) {
 		return nil
 	}
 	lit.Defaults, lit.Parameters = p.parseFunctionParameters()
-	if !p.expectPeek(token.LBRACE) {
+	if !p.expectPeek("function", token.LBRACE) {
 		return nil
 	}
 	lit.Body = p.parseBlockStatement()
@@ -725,11 +838,11 @@ func (p *Parser) parseFunctionDefinition() ast.Expression {
 	}
 	p.nextToken()
 	lit := &ast.FunctionDefineLiteral{Token: p.curToken}
-	if !p.expectPeek(token.LPAREN) {
+	if !p.expectPeek("function", token.LPAREN) {
 		return nil
 	}
 	lit.Defaults, lit.Parameters = p.parseFunctionParameters()
-	if !p.expectPeek(token.LBRACE) {
+	if !p.expectPeek("function", token.LBRACE) {
 		return nil
 	}
 	lit.Body = p.parseBlockStatement()
@@ -751,7 +864,7 @@ func (p *Parser) parseFunctionParameters() (map[string]ast.Expression, []*ast.Id
 	// Keep going until we find a ")"
 	for !p.curTokenIs(token.RPAREN) {
 		if p.curTokenIs(token.EOF) {
-			p.errors = append(p.errors, "unterminated function parameters")
+			p.setTokenError(p.prevToken, "unterminated function parameters")
 			return nil, nil
 		}
 		ident := &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
@@ -827,7 +940,7 @@ func (p *Parser) parseExpressionList(end token.Type) []ast.Expression {
 		p.nextToken()
 		list = append(list, p.parseExpression(LOWEST))
 	}
-	if !p.expectPeek(end) {
+	if !p.expectPeek("an expression list", end) {
 		return nil
 	}
 	return list
@@ -838,7 +951,7 @@ func (p *Parser) parseIndexExpression(left ast.Expression) ast.Expression {
 	exp := &ast.IndexExpression{Token: p.curToken, Left: left}
 	p.nextToken()
 	exp.Index = p.parseExpression(LOWEST)
-	if !p.expectPeek(token.RBRACKET) {
+	if !p.expectPeek("an index expression", token.RBRACKET) {
 		return nil
 	}
 	return exp
@@ -850,9 +963,7 @@ func (p *Parser) parseAssignExpression(name ast.Expression) ast.Expression {
 	if n, ok := name.(*ast.Identifier); ok {
 		stmt.Name = n
 	} else {
-		msg := fmt.Sprintf("expected assign token to be IDENT, got %s instead around line %d",
-			name.TokenLiteral(), p.curToken.Line+1)
-		p.errors = append(p.errors, msg)
+		p.setTokenError(p.curToken, "unexpected token for assignment: %s", name.TokenLiteral())
 		return nil
 	}
 	oper := p.curToken
@@ -886,7 +997,7 @@ func (p *Parser) parsePipeExpression(first ast.Expression) ast.Expression {
 	exp := &ast.PipeExpression{Token: p.curToken, Arguments: []ast.Expression{first}}
 	for {
 		if p.curTokenIs(token.EOF) {
-			p.errors = append(p.errors, "unterminated pipe expression")
+			p.setTokenError(exp.Token, "unterminated pipe expression")
 			return nil
 		}
 		// Move past the pipe operator itself
@@ -894,7 +1005,7 @@ func (p *Parser) parsePipeExpression(first ast.Expression) ast.Expression {
 		// Parse the next expression and add it to the ast.PipeExpression Arguments
 		expr := p.parseExpression(PIPE)
 		if expr == nil {
-			p.errors = append(p.errors, "unable to parse pipe expression")
+			p.setTokenError(p.curToken, "invalid pipe expression")
 			return nil
 		}
 		exp.Arguments = append(exp.Arguments, expr)
@@ -903,7 +1014,7 @@ func (p *Parser) parsePipeExpression(first ast.Expression) ast.Expression {
 			p.nextToken()
 			continue
 		} else if p.peekTokenIs(token.EOF) {
-			p.errors = append(p.errors, "unterminated pipe expression")
+			p.setTokenError(exp.Token, "unterminated pipe expression")
 			return nil
 		} else {
 			// Anything else indicates the end of the pipe expression
@@ -936,7 +1047,7 @@ func (p *Parser) parseHashLiteral() ast.Expression {
 			},
 		}
 		for !p.peekTokenIs(token.RBRACE) {
-			if !p.expectPeek(token.COMMA) {
+			if !p.expectPeek("hash", token.COMMA) {
 				return nil
 			}
 			for p.peekTokenIs(token.NEWLINE) {
@@ -957,12 +1068,12 @@ func (p *Parser) parseHashLiteral() ast.Expression {
 		for p.peekTokenIs(token.NEWLINE) {
 			p.nextToken()
 		}
-		if !p.expectPeek(token.RBRACE) {
+		if !p.expectPeek("hash", token.RBRACE) {
 			return nil
 		}
 		return hash
 	} else { // This is a set
-		if !p.expectPeek(token.COMMA) {
+		if !p.expectPeek("set", token.COMMA) {
 			return nil
 		}
 		for p.peekTokenIs(token.NEWLINE) {
@@ -984,7 +1095,7 @@ func (p *Parser) parseHashLiteral() ast.Expression {
 				p.nextToken()
 			}
 		}
-		if !p.expectPeek(token.RBRACE) {
+		if !p.expectPeek("set", token.RBRACE) {
 			return nil
 		}
 		return set
@@ -994,7 +1105,7 @@ func (p *Parser) parseHashLiteral() ast.Expression {
 func (p *Parser) parseHashKeyValue() (ast.Expression, ast.Expression) {
 	p.nextToken()
 	key := p.parseExpression(LOWEST)
-	if !p.expectPeek(token.COLON) {
+	if !p.expectPeek("hash value", token.COLON) {
 		return nil, nil
 	}
 	p.nextToken()
@@ -1027,12 +1138,12 @@ func (p *Parser) peekTokenIs(t token.Type) bool {
 
 // expectPeek validates the next token is of the given type,
 // and advances if so.  If it is not an error is stored.
-func (p *Parser) expectPeek(t token.Type) bool {
+func (p *Parser) expectPeek(context string, t token.Type) bool {
 	if p.peekTokenIs(t) {
 		p.nextToken()
 		return true
 	}
-	p.peekError(t)
+	p.peekError(context, t, p.peekToken)
 	return false
 }
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -55,8 +56,8 @@ func TestBadLetConstStatement(t *testing.T) {
 		input string
 		err   string
 	}{
-		{"let", "parse error: unexpected EOF while parsing let statement (expected an identifier)"},
-		{"const", "parse error: unexpected EOF while parsing const statement (expected an identifier)"},
+		{"let", "parse error: unexpected end of file while parsing let statement (expected identifier)"},
+		{"const", "parse error: unexpected end of file while parsing const statement (expected identifier)"},
 		{"let x;", "parse error: unexpected ; while parsing let statement (expected =)"},
 		{"const x;", "parse error: unexpected ; while parsing const statement (expected =)"},
 	}
@@ -492,7 +493,6 @@ func TestIncompleThings(t *testing.T) {
 		{`func foo( a, b ="steve", `, "parse error: unterminated function parameters"},
 		{`func foo() {`, "parse error: unterminated block statement"},
 		{`switch (foo) { `, "parse error: unterminated switch statement"},
-		{`foo | bar`, "parse error: unterminated pipe expression"}, // TODO: fix this?
 	}
 	for _, tt := range tests {
 		_, err := Parse(tt.input)
@@ -756,7 +756,8 @@ func TestUnterminatedBacktickString(t *testing.T) {
 func TestUnterminatedString(t *testing.T) {
 	input := `42
 x := "a`
-	_, err := ParseWithOpts(Opts{Input: input, File: "main.tm"})
+	ctx := context.Background()
+	_, err := ParseWithOpts(ctx, Opts{Input: input, File: "main.tm"})
 	require.NotNil(t, err)
 	fmt.Printf("%+v\n", err.(*SyntaxError).StartPosition())
 	require.Equal(t, "syntax error: unterminated string literal", err.Error())

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,12 +1,12 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/cloudcmds/tamarin/internal/ast"
-	"github.com/hashicorp/go-multierror"
+	"github.com/cloudcmds/tamarin/internal/token"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,21 +51,21 @@ func TestDeclareStatements(t *testing.T) {
 }
 
 func TestBadLetConstStatement(t *testing.T) {
-	inputs := []string{
-		"let",
-		"const",
-		"let x;",
-		"const x;",
+	inputs := []struct {
+		input string
+		err   string
+	}{
+		{"let", "parse error: unexpected EOF while parsing let statement (expected an identifier)"},
+		{"const", "parse error: unexpected EOF while parsing const statement (expected an identifier)"},
+		{"let x;", "parse error: unexpected ; while parsing let statement (expected =)"},
+		{"const x;", "parse error: unexpected ; while parsing const statement (expected =)"},
 	}
-	for _, input := range inputs {
-		_, err := Parse(input)
+	for _, tt := range inputs {
+		_, err := Parse(tt.input)
 		require.NotNil(t, err)
-		errors, ok := err.(*multierror.Error)
+		e, ok := err.(ParserError)
 		require.True(t, ok)
-		require.True(t, len(errors.Errors) > 0)
-		// TODO: confirm error message is exactly right
-		// err0 := errors.Errors[0]
-		// assert.Equal(t, err0.Error(), "foo")
+		require.Equal(t, tt.err, e.Error())
 	}
 }
 
@@ -485,22 +485,21 @@ func TestIncompleThings(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{`if ( true ) { `, "unterminated block statement"},
-		{`if ( true ) { puts( "OK" ) ; } else { `, "unterminated block statement"},
-		{`let x = `, "assignment statement is missing a value"},
-		{`const x =`, "assignment statement is missing a value"},
-		{`func foo( a, b ="steve", `, "unterminated function parameters"},
-		{`func foo() {`, "unterminated block statement"},
-		{`switch (foo) { `, "unterminated switch statement"},
-		{`foo | bar`, "unterminated pipe expression"}, // TODO: fix this?
+		{`if ( true ) { `, "parse error: unterminated block statement"},
+		{`if ( true ) { puts( "OK" ) ; } else { `, "parse error: unterminated block statement"},
+		{`let x = `, "parse error: assignment is missing a value"},
+		{`const x =`, "parse error: assignment is missing a value"},
+		{`func foo( a, b ="steve", `, "parse error: unterminated function parameters"},
+		{`func foo() {`, "parse error: unterminated block statement"},
+		{`switch (foo) { `, "parse error: unterminated switch statement"},
+		{`foo | bar`, "parse error: unterminated pipe expression"}, // TODO: fix this?
 	}
 	for _, tt := range tests {
 		_, err := Parse(tt.input)
 		require.NotNil(t, err)
-		errors, ok := err.(*multierror.Error)
+		pe, ok := err.(ParserError)
 		require.True(t, ok)
-		require.True(t, len(errors.Errors) > 0)
-		require.Equal(t, tt.expected, errors.Errors[0].Error())
+		require.Equal(t, tt.expected, pe.Error())
 	}
 }
 
@@ -542,13 +541,13 @@ default:
 }`
 	_, err := Parse(input)
 	require.NotNil(t, err)
-	errors, ok := err.(*multierror.Error)
+	parserErr, ok := err.(ParserError)
 	require.True(t, ok)
-	require.Len(t, errors.Errors, 1)
-	err0 := errors.Errors[0]
-	if !strings.Contains(err0.Error(), "only have one default block") {
-		t.Errorf("Unexpected error-message %s\n", err0)
-	}
+	require.Equal(t, "parse error: switch statement has multiple default blocks", parserErr.Error())
+	require.Equal(t, 0, parserErr.StartPosition().Column)
+	require.Equal(t, 8, parserErr.StartPosition().Line)
+	require.Equal(t, 6, parserErr.EndPosition().Column) // last col in the word "default"
+	require.Equal(t, 8, parserErr.EndPosition().Line)
 }
 
 func TestPipeExpression(t *testing.T) {
@@ -726,4 +725,64 @@ func TestBacktick(t *testing.T) {
 	str, ok := stmt.Expression.(*ast.StringLiteral)
 	require.True(t, ok)
 	require.Equal(t, `\\n\t foo bar /hey there/`, str.Value)
+}
+
+func TestUnterminatedBacktickString(t *testing.T) {
+	input := "`foo"
+	_, err := Parse(input)
+	require.NotNil(t, err)
+	require.Equal(t, "syntax error: unterminated string literal", err.Error())
+	var syntaxErr *SyntaxError
+	ok := errors.As(err, &syntaxErr)
+	require.True(t, ok)
+	require.NotNil(t, syntaxErr.Cause())
+	require.Equal(t, "unterminated string literal", syntaxErr.Cause().Error())
+	require.Equal(t, NewSyntaxError(ErrorOpts{
+		ErrType: "syntax error",
+		Cause:   syntaxErr.Cause(),
+		StartPosition: token.Position{
+			Value: rune('`'),
+		},
+		EndPosition: token.Position{
+			Value:  rune('o'),
+			Column: 3, // the last "o" in foo is at index 3
+			Char:   3, // the last "o" in foo is at index 3
+		},
+		File:       "",
+		SourceCode: "`foo",
+	}), syntaxErr)
+}
+
+func TestUnterminatedString(t *testing.T) {
+	input := `42
+x := "a`
+	_, err := ParseWithOpts(Opts{Input: input, File: "main.tm"})
+	require.NotNil(t, err)
+	fmt.Printf("%+v\n", err.(*SyntaxError).StartPosition())
+	require.Equal(t, "syntax error: unterminated string literal", err.Error())
+	var syntaxErr *SyntaxError
+	ok := errors.As(err, &syntaxErr)
+	require.True(t, ok)
+	require.NotNil(t, syntaxErr.Cause())
+	require.Equal(t, "unterminated string literal", syntaxErr.Cause().Error())
+	require.Equal(t, NewSyntaxError(ErrorOpts{
+		ErrType: "syntax error",
+		Cause:   syntaxErr.Cause(),
+		StartPosition: token.Position{
+			Value:     rune('"'),
+			Column:    5,
+			Line:      1,
+			LineStart: 3,
+			Char:      8,
+		},
+		EndPosition: token.Position{
+			Value:     rune('a'),
+			Column:    6,
+			Line:      1,
+			LineStart: 3,
+			Char:      9,
+		},
+		File:       "main.tm",
+		SourceCode: "x := \"a",
+	}), syntaxErr)
 }

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -5,13 +5,31 @@ package token
 // Type is a string
 type Type string
 
+// Position points to a particular location in an input string.
+// It helps track offset since the beginning of the input as well
+// as line offsets.
+type Position struct {
+	Value     rune
+	Char      int
+	LineStart int
+	Line      int
+	Column    int
+}
+
+func (p Position) LineNumber() int {
+	return p.Line + 1
+}
+
+func (p Position) ColumnNumber() int {
+	return p.Column + 1
+}
+
 // Token struct represent the lexer token
 type Token struct {
 	Type          Type
 	Literal       string
-	Line          int
-	StartPosition int
-	EndPosition   int
+	StartPosition Position
+	EndPosition   Position
 }
 
 // pre-defined Type

--- a/tamarin.go
+++ b/tamarin.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cloudcmds/tamarin/evaluator"
 	"github.com/cloudcmds/tamarin/exec"
+	"github.com/cloudcmds/tamarin/internal/parser"
 	"github.com/cloudcmds/tamarin/object"
 )
 
@@ -63,10 +64,12 @@ func main() {
 	// Read input
 	var err error
 	var input []byte
+	var filename string
 	if isStdinInput {
 		input, err = io.ReadAll(os.Stdin)
 	} else {
-		input, err = os.ReadFile(flag.Args()[0])
+		filename = flag.Args()[0]
+		input, err = os.ReadFile(filename)
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "input error: %s\n", err)
@@ -77,10 +80,18 @@ func main() {
 	ctx := context.Background()
 	result, err := exec.Execute(ctx, exec.Opts{
 		Input:    string(input),
+		File:     filename,
 		Importer: &evaluator.SimpleImporter{},
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
+		parserErr, ok := err.(parser.ParserError)
+		if ok {
+			fmt.Fprintf(os.Stderr, "%s\n", parserErr.Error())
+			fmt.Fprintf(os.Stderr, "\n")
+			fmt.Fprintf(os.Stderr, "%s\n", parserErr.File())
+		} else {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+		}
 		os.Exit(1)
 	}
 

--- a/tamarin.go
+++ b/tamarin.go
@@ -86,9 +86,9 @@ func main() {
 	if err != nil {
 		parserErr, ok := err.(parser.ParserError)
 		if ok {
-			fmt.Fprintf(os.Stderr, "%s\n", parserErr.Error())
-			fmt.Fprintf(os.Stderr, "\n")
-			fmt.Fprintf(os.Stderr, "%s\n", parserErr.File())
+			fmt.Fprintf(os.Stderr, "%s\n", parserErr.FriendlyMessage())
+			// fmt.Fprintf(os.Stderr, "\n")
+			// fmt.Fprintf(os.Stderr, "%s\n", parserErr.File())
 		} else {
 			fmt.Fprintf(os.Stderr, "%s\n", err)
 		}

--- a/tests/eval_test.go
+++ b/tests/eval_test.go
@@ -104,7 +104,7 @@ func listTestFiles() []string {
 }
 
 func TestFiles(t *testing.T) {
-	only := "11-19"
+	only := "" // "11-19-22"
 	for _, name := range listTestFiles() {
 		if !strings.HasSuffix(name, ".tm") {
 			continue

--- a/tests/eval_test.go
+++ b/tests/eval_test.go
@@ -2,22 +2,26 @@ package tests
 
 import (
 	"context"
-	"errors"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/cloudcmds/tamarin/evaluator"
 	"github.com/cloudcmds/tamarin/exec"
+	"github.com/cloudcmds/tamarin/internal/parser"
 	"github.com/cloudcmds/tamarin/object"
 	"github.com/stretchr/testify/require"
 )
 
 type TestCase struct {
-	Name          string
-	Text          string
-	ExpectedValue string
-	ExpectedType  string
+	Name              string
+	Text              string
+	ExpectedValue     string
+	ExpectedType      string
+	ExpectedErr       string
+	ExpectedErrLine   int
+	ExpectedErrColumn int
 }
 
 func readFile(name string) string {
@@ -28,36 +32,50 @@ func readFile(name string) string {
 	return string(data)
 }
 
-func parseExpectedValue(filename, text string) (value string, typ string, err error) {
+func parseExpectedValue(filename, text string) (TestCase, error) {
+	result := TestCase{}
 	lines := strings.Split(text, "\n")
 	for _, line := range lines {
 		if !strings.HasPrefix(line, "// ") {
 			continue
 		}
-		if strings.HasPrefix(line, "// expected value:") {
-			value = strings.SplitN(line, ":", 2)[1]
-		} else if strings.HasPrefix(line, "// expected type:") {
-			typ = strings.SplitN(line, ":", 2)[1]
+		line = strings.TrimPrefix(line, "// ")
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		val := strings.TrimSpace(parts[1])
+		switch key {
+		case "expected value":
+			result.ExpectedValue = val
+		case "expected type":
+			result.ExpectedType = val
+		case "expected error":
+			result.ExpectedErr = val
+		case "expected error line":
+			intVal, err := strconv.Atoi(val)
+			if err != nil {
+				return result, err
+			}
+			result.ExpectedErrLine = intVal
+		case "expected error column":
+			intVal, err := strconv.Atoi(val)
+			if err != nil {
+				return result, err
+			}
+			result.ExpectedErrColumn = intVal
 		}
 	}
-	if value != "" {
-		return strings.TrimSpace(value), strings.TrimSpace(typ), nil
-	}
-	return "", "", errors.New("test file did not define an expected result")
+	return result, nil
 }
 
 func getTestCase(name string) (TestCase, error) {
 	input := readFile(name)
-	expectedValue, expectedType, err := parseExpectedValue(name, input)
-	if err != nil {
-		return TestCase{}, err
-	}
-	return TestCase{
-		Name:          name,
-		Text:          input,
-		ExpectedValue: expectedValue,
-		ExpectedType:  expectedType,
-	}, nil
+	testCase, err := parseExpectedValue(name, input)
+	testCase.Name = name
+	testCase.Text = input
+	return testCase, err
 }
 
 func execute(ctx context.Context, input string) (object.Object, error) {
@@ -86,22 +104,43 @@ func listTestFiles() []string {
 }
 
 func TestFiles(t *testing.T) {
+	only := "11-19"
 	for _, name := range listTestFiles() {
 		if !strings.HasSuffix(name, ".tm") {
+			continue
+		}
+		if only != "" && !strings.Contains(name, only) {
 			continue
 		}
 		t.Run(name, func(t *testing.T) {
 			tc, err := getTestCase(name)
 			require.Nil(t, err)
-
 			ctx := context.Background()
 			result, err := execute(ctx, tc.Text)
-			require.Nil(t, err)
-
 			expectedType := object.Type(tc.ExpectedType)
 
-			require.Equal(t, tc.ExpectedValue, result.Inspect())
-			require.Equal(t, expectedType, result.Type())
+			if tc.ExpectedValue != "" {
+				require.Equal(t, tc.ExpectedValue, result.Inspect())
+			}
+			if tc.ExpectedType != "" {
+				require.Equal(t, expectedType, result.Type())
+			}
+			if tc.ExpectedErr != "" {
+				require.NotNil(t, err)
+				require.Equal(t, tc.ExpectedErr, err.Error())
+			}
+			if tc.ExpectedErrColumn != 0 {
+				require.NotNil(t, err)
+				parserErr, ok := err.(parser.ParserError)
+				require.True(t, ok)
+				require.Equal(t, tc.ExpectedErrColumn, parserErr.StartPosition().ColumnNumber())
+			}
+			if tc.ExpectedErrLine != 0 {
+				require.NotNil(t, err)
+				parserErr, ok := err.(parser.ParserError)
+				require.True(t, ok)
+				require.Equal(t, tc.ExpectedErrLine, parserErr.StartPosition().LineNumber())
+			}
 		})
 	}
 }

--- a/tests/eval_test.go
+++ b/tests/eval_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -104,7 +105,7 @@ func listTestFiles() []string {
 }
 
 func TestFiles(t *testing.T) {
-	only := "" // "11-19-22"
+	only := ""
 	for _, name := range listTestFiles() {
 		if !strings.HasSuffix(name, ".tm") {
 			continue
@@ -120,10 +121,18 @@ func TestFiles(t *testing.T) {
 			expectedType := object.Type(tc.ExpectedType)
 
 			if tc.ExpectedValue != "" {
-				require.Equal(t, tc.ExpectedValue, result.Inspect())
+				if result == nil {
+					t.Fatalf("expected value %q, got nil", tc.ExpectedValue)
+				} else {
+					require.Equal(t, tc.ExpectedValue, result.Inspect())
+				}
 			}
 			if tc.ExpectedType != "" {
-				require.Equal(t, expectedType, result.Type())
+				if result == nil {
+					t.Fatalf("expected type %q, got nil", tc.ExpectedType)
+				} else {
+					require.Equal(t, expectedType, result.Type())
+				}
 			}
 			if tc.ExpectedErr != "" {
 				require.NotNil(t, err)
@@ -133,13 +142,25 @@ func TestFiles(t *testing.T) {
 				require.NotNil(t, err)
 				parserErr, ok := err.(parser.ParserError)
 				require.True(t, ok)
-				require.Equal(t, tc.ExpectedErrColumn, parserErr.StartPosition().ColumnNumber())
+				fmt.Println("--- Friendly error output for", name)
+				fmt.Println(parserErr.FriendlyMessage())
+				fmt.Println("---")
+				require.Equal(t,
+					tc.ExpectedErrColumn,
+					parserErr.StartPosition().ColumnNumber(),
+					"The column number is incorrect")
 			}
 			if tc.ExpectedErrLine != 0 {
 				require.NotNil(t, err)
 				parserErr, ok := err.(parser.ParserError)
 				require.True(t, ok)
-				require.Equal(t, tc.ExpectedErrLine, parserErr.StartPosition().LineNumber())
+				fmt.Println("--- Friendly error output for", name)
+				fmt.Println(parserErr.FriendlyMessage())
+				fmt.Println("---")
+				require.Equal(t,
+					tc.ExpectedErrLine,
+					parserErr.StartPosition().LineNumber(),
+					"The line number is incorrect")
 			}
 		})
 	}

--- a/tests/test-2022-11-18-17-15.tm
+++ b/tests/test-2022-11-18-17-15.tm
@@ -1,5 +1,7 @@
 // expected error: parse error: illegal token '
 // expected error line: 7
-// expected error column: 6
+// expected error column: 7
 
-a := 'abc'
+
+
+a :=  'abc'

--- a/tests/test-2022-11-18-17-15.tm
+++ b/tests/test-2022-11-18-17-15.tm
@@ -1,0 +1,5 @@
+// expected error: parse error: illegal token '
+// expected error line: 7
+// expected error column: 6
+
+a := 'abc'

--- a/tests/test-2022-11-19-21-41.tm
+++ b/tests/test-2022-11-19-21-41.tm
@@ -1,0 +1,6 @@
+// expected error: parse error: assignment is missing a value
+// expected error line: 6
+// expected error column: 9
+
+let x = 42
+let y = 

--- a/tests/test-2022-11-19-22-23.tm
+++ b/tests/test-2022-11-19-22-23.tm
@@ -1,0 +1,5 @@
+// expected error: parse error: unexpected token in for loop: (
+// expected error line: 5
+// expected error column: 7
+
+ for  ( // BROKEN LOOP

--- a/tests/test-2022-11-20-09-02.tm
+++ b/tests/test-2022-11-20-09-02.tm
@@ -1,0 +1,7 @@
+// expected error: parse error: unexpected token in for loop: newline
+// expected error line: 7
+// expected error column: 5
+
+
+
+for 

--- a/tests/test-2022-11-21-08-42.tm
+++ b/tests/test-2022-11-21-08-42.tm
@@ -1,0 +1,6 @@
+// github issue: https://github.com/cloudcmds/tamarin/issues/6
+// expected error: syntax error: unterminated string literal
+// expected error line: 6
+// expected error column: 9
+
+line := `hello there


### PR DESCRIPTION
- Refactor lexer to more fully capture token start and end positions.
- Update APIs to support passing filenames through. 
- Update tests to support checking for expected error messages and line/col numbers
- Add test cases for unterminated strings, single quote strings (invalid), and other examples of invalid syntax
- Add "friendly" error messages that include the line/col numbers, filename, and highlight the problematic token